### PR TITLE
Add yats.vim to editor support

### DIFF
--- a/TypeScript-Editor-Support.md
+++ b/TypeScript-Editor-Support.md
@@ -11,7 +11,8 @@
 # Vim
 
 ### Syntax highlight
-[leafgarland/typescript-vim](https://github.com/leafgarland/typescript-vim) provides syntax files for highlighting .ts and .d.ts files. 
+* [leafgarland/typescript-vim](https://github.com/leafgarland/typescript-vim) provides syntax files for highlighting .ts and .d.ts files. 
+* [HerringtonDarkholme/yats.vim](https://github.com/HerringtonDarkholme/yats.vim) provides more syntax highlighting and DOM keywords.
 
 ### Language Service Tools
 There are two main TypeScript plugins:


### PR DESCRIPTION
YATS is yet another TypeScript syntax file for Vim. It provides exuberant highlighting and a lot DOM keywords.
